### PR TITLE
Add middleware directory and hook up transactions router

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,45 @@
+# La Virtual Zone Backend
+
+## Manual Verification Steps for Transactions
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+
+2. Start the server:
+   ```bash
+   node server.js
+   ```
+
+3. Register a user and obtain a token:
+   ```bash
+   curl -X POST http://localhost:5000/api/auth/register \
+     -H "Content-Type: application/json" \
+     -d '{"name":"Test","email":"test@example.com","password":"pass","parsecId":"123"}'
+   ```
+   Save the `token` returned in the response.
+
+4. Create a club for the user (required before making transactions):
+   ```bash
+   curl -X POST http://localhost:5000/api/club \
+     -H "Content-Type: application/json" \
+     -H "x-auth-token: YOUR_TOKEN" \
+     -d '{"name":"My Club","color":"blue"}'
+   ```
+
+5. Create a transaction using the token:
+   ```bash
+   curl -X POST http://localhost:5000/api/transactions \
+     -H "Content-Type: application/json" \
+     -H "x-auth-token: YOUR_TOKEN" \
+     -d '{"type":"compra","playerId":"PLAYER_ID","value":1000}'
+   ```
+   Replace `PLAYER_ID` with a valid player id from your database.
+
+6. Verify the response contains the created transaction. You can list all transactions:
+   ```bash
+   curl -H "x-auth-token: YOUR_TOKEN" http://localhost:5000/api/transactions
+   ```
+
+These steps confirm that authentication middleware works with the transaction routes.

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -1,0 +1,13 @@
+const jwt = require('jsonwebtoken');
+
+module.exports = function(req, res, next) {
+  const token = req.headers.authorization?.split(' ')[1] || req.header('x-auth-token');
+  if (!token) return res.status(401).json({ message: 'No autorizado' });
+  try {
+    const decoded = jwt.verify(token, process.env.JWT_SECRET || 'tu_secreto_muy_largo_y_seguro');
+    req.user = { id: decoded.id };
+    next();
+  } catch (err) {
+    res.status(401).json({ message: 'Token inválido' });
+  }
+};

--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -1,0 +1,8 @@
+module.exports.validateRequiredFields = function(req, res, fields) {
+  const missing = fields.filter(field => !req.body[field]);
+  if (missing.length) {
+    res.status(400).json({ message: `Faltan campos requeridos: ${missing.join(', ')}` });
+    return true;
+  }
+  return false;
+};

--- a/server.js
+++ b/server.js
@@ -1,7 +1,5 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const jwt = require('jsonwebtoken');
-const bcrypt = require('bcryptjs');
 const cors = require('cors');
 const path = require('path');
 
@@ -16,7 +14,6 @@ app.use(express.json());
 // Configuración de variables de entorno
 const PORT = process.env.PORT || 5000;
 const MONGO_URI = process.env.MONGO_URI || 'mongodb+srv://jackson:lolitopro123@cluster0.6gaqc.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0';
-const JWT_SECRET = process.env.JWT_SECRET || 'tu_secreto_muy_largo_y_seguro'; // Cambia esto en producción
 
 // Middleware para registrar solicitudes
 app.use((req, res, next) => {
@@ -33,23 +30,10 @@ mongoose.connect(MONGO_URI, { useNewUrlParser: true, useUnifiedTopology: true })
   .catch(err => console.error('Error de conexión a MongoDB:', err));
 
 // Importar modelos desde la carpeta models/
-const User = require('./models/User');
 const Club = require('./models/Club');
-const Player = require('./models/Player');
-const Transaction = require('./models/Transaction');
 
 // Middleware de autenticación
-const auth = (req, res, next) => {
-  const token = req.headers.authorization?.split(' ')[1] || req.header('x-auth-token');
-  if (!token) return res.status(401).json({ message: 'No autorizado' });
-  try {
-    const decoded = jwt.verify(token, JWT_SECRET);
-    req.user = decoded.id;
-    next();
-  } catch (err) {
-    res.status(401).json({ message: 'Token inválido' });
-  }
-};
+const auth = require('./middleware/auth');
 
 // Rutas modulares
 const authRoutes = require('./routes/auth');
@@ -60,37 +44,8 @@ app.use('/api/auth', authRoutes);
 app.use('/api/club', clubRoutes);
 app.use('/api/players', playerRoutes);
 
-// Ruta de transacción
-app.post('/api/transaction', auth, async (req, res) => {
-  try {
-    const { type, playerName, value } = req.body;
-    const club = await Club.findOne({ userId: req.user });
-    if (!club) return res.status(404).json({ message: 'Club no encontrado' });
-    if (type === 'compra' && club.budget < value) {
-      return res.status(400).json({ message: 'Presupuesto insuficiente' });
-    }
-    const transaction = new Transaction({ userId: req.user, type, playerName, value });
-    await transaction.save();
-    if (type === 'compra') {
-      club.budget -= value;
-      const player = await Player.findOne({ name: playerName });
-      if (player) club.players.push(player._id);
-    } else if (type === 'venta') {
-      club.budget += value;
-      const player = await Player.findOne({ name: playerName });
-      if (player) club.players = club.players.filter(p => p.toString() !== player._id.toString());
-    } else if (type === 'prestamo') {
-      club.budget -= value;
-      const player = await Player.findOne({ name: playerName });
-      if (player) club.players.push(player._id);
-    }
-    await club.save();
-    res.status(201).json({ message: 'Transacción registrada exitosamente', transaction });
-  } catch (error) {
-    console.error('Error en /api/transaction:', error);
-    res.status(500).json({ message: 'Error en el servidor' });
-  }
-});
+const transactionRoutes = require('./routes/transactions');
+app.use('/api/transactions', transactionRoutes);
 
 // Contar clubes para estadísticas
 app.get('/api/club/count', auth, async (req, res) => {


### PR DESCRIPTION
## Summary
- add auth and validation middleware
- document manual steps for testing transaction routes
- mount `/api/transactions` router in server

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68521ea8ef8483339a240be970eb5558